### PR TITLE
Add support for missing BeginIf conditions on x86

### DIFF
--- a/build_android/src/main/jni/Android.mk
+++ b/build_android/src/main/jni/Android.mk
@@ -53,6 +53,7 @@ LOCAL_SRC_FILES			:=	$(PROJECT_PATH)/tests/AliasTest.cpp \
 							$(PROJECT_PATH)/tests/AliasTest2.cpp \
 							$(PROJECT_PATH)/tests/Alu64Test.cpp \
 							$(PROJECT_PATH)/tests/Call64Test.cpp \
+							$(PROJECT_PATH)/tests/ConditionTest.cpp \
 							$(PROJECT_PATH)/tests/Cmp64Test.cpp \
 							$(PROJECT_PATH)/tests/CompareTest.cpp \
 							$(PROJECT_PATH)/tests/Crc32Test.cpp \

--- a/build_ios/CodeGenTestSuite.xcodeproj/project.pbxproj
+++ b/build_ios/CodeGenTestSuite.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03E0AC3B1D629D5900346464 /* ConditionTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03E0AC391D629D5900346464 /* ConditionTest.cpp */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
@@ -88,6 +89,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		03E0AC391D629D5900346464 /* ConditionTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ConditionTest.cpp; path = ../tests/ConditionTest.cpp; sourceTree = "<group>"; };
+		03E0AC3A1D629D5900346464 /* ConditionTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConditionTest.h; path = ../tests/ConditionTest.h; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* CodeGenTestSuite.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeGenTestSuite.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -300,6 +303,8 @@
 				7E2720351212598B00C0DEBF /* CompareTest.cpp */,
 				7E2720361212598B00C0DEBF /* CompareTest.h */,
 				7E2720371212598B00C0DEBF /* Crc32Test.cpp */,
+				03E0AC391D629D5900346464 /* ConditionTest.cpp */,
+				03E0AC3A1D629D5900346464 /* ConditionTest.h */,
 				7E2720381212598B00C0DEBF /* Crc32Test.h */,
 				70AD23491B389DDA00137AA0 /* DivTest.cpp */,
 				70AD234A1B389DDA00137AA0 /* DivTest.h */,
@@ -509,6 +514,7 @@
 				7031AA4D1AED887C00FA7B53 /* MdAddTest.cpp in Sources */,
 				7EE2D43A1228842C00C2C057 /* RegAllocTest.cpp in Sources */,
 				703D964A1AE497D000B3974D /* MdCmpTest.cpp in Sources */,
+				03E0AC3B1D629D5900346464 /* ConditionTest.cpp in Sources */,
 				7EF8380512DAB5D300EA0F1C /* AliasTest.cpp in Sources */,
 				704F23A51B0010DF009FD916 /* ShiftTest.cpp in Sources */,
 				703093CC17BE67E5009662A1 /* Alu64Test.cpp in Sources */,

--- a/build_macosx/CodeGenTestSuite.xcodeproj/project.pbxproj
+++ b/build_macosx/CodeGenTestSuite.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03E0AC361D629D2100346464 /* ConditionTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03E0AC341D629D2100346464 /* ConditionTest.cpp */; };
 		701249831B02E97A005F341A /* MdMinMaxTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 701249811B02E97A005F341A /* MdMinMaxTest.cpp */; };
 		7031AA571AED88B800FA7B53 /* MdAddTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7031AA531AED88B800FA7B53 /* MdAddTest.cpp */; };
 		7031AA581AED88B800FA7B53 /* NestedIfTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7031AA551AED88B800FA7B53 /* NestedIfTest.cpp */; };
@@ -94,6 +95,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		03E0AC341D629D2100346464 /* ConditionTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ConditionTest.cpp; path = ../tests/ConditionTest.cpp; sourceTree = "<group>"; };
+		03E0AC351D629D2100346464 /* ConditionTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConditionTest.h; path = ../tests/ConditionTest.h; sourceTree = "<group>"; };
 		701249811B02E97A005F341A /* MdMinMaxTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MdMinMaxTest.cpp; path = ../tests/MdMinMaxTest.cpp; sourceTree = "<group>"; };
 		701249821B02E97A005F341A /* MdMinMaxTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MdMinMaxTest.h; path = ../tests/MdMinMaxTest.h; sourceTree = "<group>"; };
 		7031AA531AED88B800FA7B53 /* MdAddTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MdAddTest.cpp; path = ../tests/MdAddTest.cpp; sourceTree = "<group>"; };
@@ -255,6 +258,8 @@
 				70BFC4F61A5530EF0094CD9F /* Cmp64Test.cpp */,
 				70BFC4F71A5530EF0094CD9F /* Cmp64Test.h */,
 				70BFC5141A560A3F0094CD9F /* CodeGen_Prefix.pch */,
+				03E0AC341D629D2100346464 /* ConditionTest.cpp */,
+				03E0AC351D629D2100346464 /* ConditionTest.h */,
 				7E207C181507D5F200EE8C4F /* CompareTest.cpp */,
 				7E207C191507D5F200EE8C4F /* CompareTest.h */,
 				7E207C1A1507D5F200EE8C4F /* Crc32Test.cpp */,
@@ -439,6 +444,7 @@
 				7031AA571AED88B800FA7B53 /* MdAddTest.cpp in Sources */,
 				7E207C481507D5F200EE8C4F /* MdFpTest.cpp in Sources */,
 				703D96521AE4985100B3974D /* MdCmpTest.cpp in Sources */,
+				03E0AC361D629D2100346464 /* ConditionTest.cpp in Sources */,
 				7E207C491507D5F200EE8C4F /* MdTest.cpp in Sources */,
 				704F23AA1B001114009FD916 /* ShiftTest.cpp in Sources */,
 				7E207C4A1507D5F200EE8C4F /* MemAccessTest.cpp in Sources */,

--- a/build_unix/CMakeLists.txt
+++ b/build_unix/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(CodeGenTest
 	../tests/AliasTest2.cpp
 	../tests/Alu64Test.cpp
 	../tests/Call64Test.cpp
+	../tests/ConditionTest.cpp
 	../tests/Cmp64Test.cpp
 	../tests/CompareTest.cpp
 	../tests/Crc32Test.cpp

--- a/build_win32/CodeGenTestSuite.vcxproj
+++ b/build_win32/CodeGenTestSuite.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="..\tests\Call64Test.cpp" />
     <ClCompile Include="..\tests\Cmp64Test.cpp" />
     <ClCompile Include="..\tests\CompareTest.cpp" />
+    <ClCompile Include="..\tests\ConditionTest.cpp" />
     <ClCompile Include="..\tests\Crc32Test.cpp" />
     <ClCompile Include="..\tests\DivTest.cpp" />
     <ClCompile Include="..\tests\FpIntMixTest.cpp" />
@@ -199,6 +200,7 @@
     <ClInclude Include="..\tests\Call64Test.h" />
     <ClInclude Include="..\tests\Cmp64Test.h" />
     <ClInclude Include="..\tests\CompareTest.h" />
+    <ClInclude Include="..\tests\ConditionTest.h" />
     <ClInclude Include="..\tests\Crc32Test.h" />
     <ClInclude Include="..\tests\DivTest.h" />
     <ClInclude Include="..\tests\FpIntMixTest.h" />

--- a/build_win32/CodeGenTestSuite.vcxproj.filters
+++ b/build_win32/CodeGenTestSuite.vcxproj.filters
@@ -136,6 +136,9 @@
     <ClCompile Include="..\tests\AliasTest2.cpp">
       <Filter>Source Files\Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\tests\ConditionTest.cpp">
+      <Filter>Source Files\Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\tests\Test.h">
@@ -256,6 +259,9 @@
       <Filter>Source Files\Tests</Filter>
     </ClInclude>
     <ClInclude Include="..\tests\AliasTest2.h">
+      <Filter>Source Files\Tests</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tests\ConditionTest.h">
       <Filter>Source Files\Tests</Filter>
     </ClInclude>
   </ItemGroup>

--- a/include/X86Assembler.h
+++ b/include/X86Assembler.h
@@ -138,6 +138,7 @@ public:
 	void									ImulEw(const CAddress&);
 	void									ImulEd(const CAddress&);
 	void									JbJx(LABEL);
+	void									JbeJx(LABEL);
 	void									JnbJx(LABEL);
 	void									JzJx(LABEL);
 	void									JnlJx(LABEL);
@@ -146,6 +147,7 @@ public:
 	void									JleJx(LABEL);
 	void									JmpJx(LABEL);
 	void									JnzJx(LABEL);
+	void									JnbeJx(LABEL);
 	void									JnoJx(LABEL);
 	void									JnsJx(LABEL);
 	void									LeaGd(REGISTER, const CAddress&);

--- a/src/Jitter.cpp
+++ b/src/Jitter.cpp
@@ -100,6 +100,21 @@ CONDITION CJitter::GetReverseCondition(CONDITION condition)
 	case CONDITION_GT:
 		return CONDITION_LE;
 		break;
+	case CONDITION_GE:
+		return CONDITION_LT;
+		break;
+	case CONDITION_BL:
+		return CONDITION_AE;
+		break;
+	case CONDITION_BE:
+		return CONDITION_AB;
+		break;
+	case CONDITION_AB:
+		return CONDITION_BE;
+		break;
+	case CONDITION_AE:
+		return CONDITION_BL;
+		break;
 	default:
 		assert(0);
 		break;

--- a/src/Jitter_CodeGen_x86.cpp
+++ b/src/Jitter_CodeGen_x86.cpp
@@ -873,6 +873,18 @@ void CCodeGen_x86::CondJmp_JumpTo(CX86Assembler::LABEL label, Jitter::CONDITION 
 	case CONDITION_NE:
 		m_assembler.JnzJx(label);
 		break;
+	case CONDITION_BL:
+		m_assembler.JbJx(label);
+		break;
+	case CONDITION_BE:
+		m_assembler.JbeJx(label);
+		break;
+	case CONDITION_AB:
+		m_assembler.JnbeJx(label);
+		break;
+	case CONDITION_AE:
+		m_assembler.JnbJx(label);
+		break;
 	case CONDITION_LT:
 		m_assembler.JlJx(label);
 		break;

--- a/src/X86Assembler.cpp
+++ b/src/X86Assembler.cpp
@@ -459,6 +459,11 @@ void CX86Assembler::JbJx(LABEL label)
 	CreateLabelReference(label, JMP_B);
 }
 
+void CX86Assembler::JbeJx(LABEL label)
+{
+	CreateLabelReference(label, JMP_BE);
+}
+
 void CX86Assembler::JnbJx(LABEL label)
 {
 	CreateLabelReference(label, JMP_NB);
@@ -497,6 +502,11 @@ void CX86Assembler::JzJx(LABEL label)
 void CX86Assembler::JnzJx(LABEL label)
 {
 	CreateLabelReference(label, JMP_NZ);
+}
+
+void CX86Assembler::JnbeJx(LABEL label)
+{
+	CreateLabelReference(label, JMP_NBE);
 }
 
 void CX86Assembler::JnoJx(LABEL label)

--- a/tests/ConditionTest.cpp
+++ b/tests/ConditionTest.cpp
@@ -1,0 +1,103 @@
+#include "ConditionTest.h"
+#include "MemStream.h"
+
+CConditionTest::CConditionTest(bool useConstant, uint32 value0, uint32 value1)
+: m_useConstant(useConstant)
+, m_value0(value0)
+, m_value1(value1)
+{
+
+}
+
+void CConditionTest::Run()
+{
+	memset(&m_context, 0, sizeof(m_context));
+
+	m_context.value0 = m_value0;
+	m_context.value1 = m_value1;
+
+	//initalize result to nonzero to confirm that result is set to zero
+	//if "else" is taken
+	m_context.resultEq = m_context.resultNe = 0xdeadbeef;
+	m_context.resultBl = m_context.resultBe = m_context.resultAe = m_context.resultLt = 0xdeadbeef;
+	m_context.resultLe = m_context.resultAb = m_context.resultGt = m_context.resultGe = 0xdeadbeef;
+
+	m_function(&m_context);
+
+	uint32 resultEq = (m_value0 == m_value1) ? 1 : 0;
+	uint32 resultNe = (m_value0 != m_value1) ? 1 : 0;
+
+	uint32 resultBl = static_cast<uint32>(m_value0) < static_cast<uint32>(m_value1) ? 1 : 0;
+	uint32 resultBe = static_cast<uint32>(m_value0) <= static_cast<uint32>(m_value1) ? 1 : 0;
+	uint32 resultAb = static_cast<uint32>(m_value0) > static_cast<uint32>(m_value1) ? 1 : 0;
+	uint32 resultAe = static_cast<uint32>(m_value0) >= static_cast<uint32>(m_value1) ? 1 : 0;
+
+	uint32 resultLt = static_cast<int32>(m_value0) < static_cast<int32>(m_value1) ? 1 : 0;
+	uint32 resultLe = static_cast<int32>(m_value0) <= static_cast<int32>(m_value1) ? 1 : 0;
+	uint32 resultGt = static_cast<int32>(m_value0) > static_cast<int32>(m_value1) ? 1 : 0;
+	uint32 resultGe = static_cast<int32>(m_value0) >= static_cast<int32>(m_value1) ? 1 : 0;
+
+	TEST_VERIFY(m_context.resultEq == resultEq);
+	TEST_VERIFY(m_context.resultNe == resultNe);
+
+	TEST_VERIFY(m_context.resultBl == resultBl);
+	TEST_VERIFY(m_context.resultBe == resultBe);
+	TEST_VERIFY(m_context.resultAb == resultAb);
+	TEST_VERIFY(m_context.resultAe == resultAe);
+
+	TEST_VERIFY(m_context.resultLt == resultLt);
+	TEST_VERIFY(m_context.resultLe == resultLe);
+	TEST_VERIFY(m_context.resultGt == resultGt);
+	TEST_VERIFY(m_context.resultGe == resultGe);
+}
+
+void CConditionTest::MakeBeginIfCase(Jitter::CJitter& jitter, Jitter::CONDITION cond, size_t result)
+{
+	jitter.PushRel(offsetof(CONTEXT, value0));
+
+	if (m_useConstant)
+	{
+		jitter.PushCst(m_value1);
+	}
+	else
+	{
+		jitter.PushRel(offsetof(CONTEXT, value1));
+	}
+
+	jitter.BeginIf(cond);
+	{
+		jitter.PushCst(1);
+		jitter.PullRel(result);
+	}
+	jitter.Else();
+	{
+		jitter.PushCst(0);
+		jitter.PullRel(result);
+	}
+	jitter.EndIf();
+}
+
+void CConditionTest::Compile(Jitter::CJitter& jitter)
+{
+	Framework::CMemStream codeStream;
+	jitter.SetStream(&codeStream);
+
+	jitter.Begin();
+	{
+		MakeBeginIfCase(jitter, Jitter::CONDITION_EQ, offsetof(CONTEXT, resultEq));
+		MakeBeginIfCase(jitter, Jitter::CONDITION_NE, offsetof(CONTEXT, resultNe));
+
+		MakeBeginIfCase(jitter, Jitter::CONDITION_BL, offsetof(CONTEXT, resultBl));
+		MakeBeginIfCase(jitter, Jitter::CONDITION_BE, offsetof(CONTEXT, resultBe));
+		MakeBeginIfCase(jitter, Jitter::CONDITION_AB, offsetof(CONTEXT, resultAb));
+		MakeBeginIfCase(jitter, Jitter::CONDITION_AE, offsetof(CONTEXT, resultAe));
+
+		MakeBeginIfCase(jitter, Jitter::CONDITION_LT, offsetof(CONTEXT, resultLt));
+		MakeBeginIfCase(jitter, Jitter::CONDITION_LE, offsetof(CONTEXT, resultLe));
+		MakeBeginIfCase(jitter, Jitter::CONDITION_GT, offsetof(CONTEXT, resultGt));
+		MakeBeginIfCase(jitter, Jitter::CONDITION_GE, offsetof(CONTEXT, resultGe));
+	}
+	jitter.End();
+
+	m_function = CMemoryFunction(codeStream.GetBuffer(), codeStream.GetSize());
+}

--- a/tests/ConditionTest.h
+++ b/tests/ConditionTest.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Test.h"
+#include "MemoryFunction.h"
+
+class CConditionTest : public CTest
+{
+public:
+						CConditionTest(bool, uint32, uint32);
+
+	void				Run();
+	void				Compile(Jitter::CJitter&);
+
+private:
+
+	void MakeBeginIfCase(Jitter::CJitter& jitter, Jitter::CONDITION, size_t result);
+
+	struct CONTEXT
+	{
+		uint32			value0;
+		uint32			value1;
+
+		uint32			resultEq;
+		uint32			resultNe;
+		uint32			resultBl;
+		uint32			resultBe;
+		uint32			resultAe;
+		uint32			resultLt;
+		uint32			resultLe;
+		uint32			resultAb;
+		uint32			resultGt;
+		uint32			resultGe;
+	};
+
+	bool				m_useConstant = false;
+	uint32				m_value0 = 0;
+	uint32				m_value1 = 0;
+	CONTEXT				m_context;
+	CMemoryFunction		m_function;
+};

--- a/tests/Main.cpp
+++ b/tests/Main.cpp
@@ -31,6 +31,7 @@
 #include "MemAccessTest.h"
 #include "HugeJumpTest.h"
 #include "Alu64Test.h"
+#include "ConditionTest.h"
 #include "Cmp64Test.h"
 #include "Shift64Test.h"
 #include "Logic64Test.h"
@@ -96,6 +97,33 @@ static const TestFactoryFunction s_factories[] =
 	[] () { return new CMdShiftTest(32); },
 	[] () { return new CMdShiftTest(38); },
 	[] () { return new CAlu64Test(); },
+	//negative / positive
+	[] () { return new CConditionTest(false,	0xFFFFFFFE, 0xFFFFFFFE); },
+	[] () { return new CConditionTest(false,	0x00000002, 0xFFFFFFFE); },
+	[] () { return new CConditionTest(false,	0xFFFFFFFE, 0x00000002); },
+	[] () { return new CConditionTest(false,	0x00000002, 0x00000002); },
+	[] () { return new CConditionTest(true,	0xFFFFFFFE, 0xFFFFFFFE); },
+	[] () { return new CConditionTest(true,	0x00000002, 0xFFFFFFFE); },
+	[] () { return new CConditionTest(true,	0xFFFFFFFE, 0x00000002); },
+	[] () { return new CConditionTest(true,	0x00000002, 0x00000002); },
+	//negative / negative
+	[]() { return new CConditionTest(false,	0xFFFFFFF0, 0xFFFFFFF0); },
+	[]() { return new CConditionTest(false,	0xFFFFFF00, 0xFFFFFFF0); },
+	[]() { return new CConditionTest(false,	0xFFFFFFF0, 0xFFFFFF00); },
+	[]() { return new CConditionTest(false,	0xFFFFFF00, 0xFFFFFF00); },
+	[]() { return new CConditionTest(true,	0xFFFFFFF0, 0xFFFFFFF0); },
+	[]() { return new CConditionTest(true,	0xFFFFFF00, 0xFFFFFFF0); },
+	[]() { return new CConditionTest(true,	0xFFFFFFF0, 0xFFFFFF00); },
+	[]() { return new CConditionTest(true,	0xFFFFFF00, 0xFFFFFF00); },
+	//positive / positive
+	[]() { return new CConditionTest(false,	0x0000000F, 0x0000000F); },
+	[]() { return new CConditionTest(false,	0x000000FF, 0x0000000F); },
+	[]() { return new CConditionTest(false,	0x0000000F, 0x000000FF); },
+	[]() { return new CConditionTest(false,	0x000000FF, 0x000000FF); },
+	[]() { return new CConditionTest(true,	0x0000000F, 0x0000000F); },
+	[]() { return new CConditionTest(true,	0x000000FF, 0x0000000F); },
+	[]() { return new CConditionTest(true,	0x0000000F, 0x000000FF); },
+	[]() { return new CConditionTest(true,	0x000000FF, 0x000000FF); },
 	[] () { return new CCmp64Test(false,	0xFEDCBA9876543210ULL, 0x012389AB4567CDEFULL); },
 	[] () { return new CCmp64Test(true,		0xFEDCBA9876543210ULL, 0x012389AB4567CDEFULL); },
 	[] () { return new CCmp64Test(false,	0xFFFFFFFFF6543210ULL, 0xFFFFFFFFF567CDEFULL); },


### PR DESCRIPTION
This PR adds support for using the GE, BL, BE, AB and AE conditions in BeginIf statements on x86. Tests covering all the conditions have been included in tests/ComparisonTest.cpp.