### PR TITLE
Set deployment target for OS X static lib.

### DIFF
--- a/build_macosx/CodeGen.xcodeproj/project.pbxproj
+++ b/build_macosx/CodeGen.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
@@ -275,6 +276,7 @@
 			buildSettings = {
 				COPY_PHASE_STRIP = YES;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				SDKROOT = macosx;
 			};
 			name = Release;


### PR DESCRIPTION
This quiets a lot of linking warnings in regards to linking against different OS X deployment targets. 