### PR TITLE
Added header needed for uintptr_t

### DIFF
--- a/src/MemoryFunction.cpp
+++ b/src/MemoryFunction.cpp
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <assert.h>
 #include <algorithm>
+#include <cstdint>
 #include "AlignedAlloc.h"
 #include "MemoryFunction.h"
 


### PR DESCRIPTION
The header cstdint is required for uintptr_t per C++11.  This is an optional definition in the spec so we may have problems on other platforms where the standard library does not define this.