### PR TITLE
find constants that can be added together

### DIFF
--- a/include/Jitter.h
+++ b/include/Jitter.h
@@ -288,6 +288,7 @@ namespace Jitter
 		bool							ConstantFolding(StatementList&);
 		bool							ConstantPropagation(StatementList&);
 		bool							CopyPropagation(StatementList&);
+		bool							CopyPropagation2(StatementList&);
 		bool							DeadcodeElimination(VERSIONED_STATEMENT_LIST&);
 
 		void							FixFlowControl(StatementList&);

--- a/include/Jitter.h
+++ b/include/Jitter.h
@@ -288,7 +288,7 @@ namespace Jitter
 		bool							ConstantFolding(StatementList&);
 		bool							ConstantPropagation(StatementList&);
 		bool							CopyPropagation(StatementList&);
-		bool							CopyPropagation2(StatementList&);
+		bool							ReorderAdd(StatementList&);
 		bool							DeadcodeElimination(VERSIONED_STATEMENT_LIST&);
 
 		void							FixFlowControl(StatementList&);

--- a/src/Jitter_Optimize.cpp
+++ b/src/Jitter_Optimize.cpp
@@ -1175,24 +1175,22 @@ bool CJitter::ReorderAdd(StatementList& statements)
 
 			//Check for OP_SLL that uses the result of this operation and propagate the shift
 			auto innerStatementIterator = std::next(outerStatementIterator);
+			STATEMENT& innerStatement(*innerStatementIterator);
+			if(innerStatement.op == OP_SLL && innerStatement.src1->Equals(outerDstSymbol))
 			{
-				STATEMENT& innerStatement(*innerStatementIterator);
-				if(innerStatement.op == OP_SLL && innerStatement.src1->Equals(outerDstSymbol))
+				CSymbol* innerSrc2cst = dynamic_symbolref_cast(SYM_CONSTANT, innerStatement.src2);
+				CSymbol* outerSrc2cst = dynamic_symbolref_cast(SYM_CONSTANT, outerStatement.src2);
+				if(innerSrc2cst && outerSrc2cst)
 				{
-					CSymbol* innerSrc2cst = dynamic_symbolref_cast(SYM_CONSTANT, innerStatement.src2);
-					CSymbol* outerSrc2cst = dynamic_symbolref_cast(SYM_CONSTANT, outerStatement.src2);
-					if(innerSrc2cst && outerSrc2cst)
-					{
-						uint32 result = outerSrc2cst->m_valueLow << innerSrc2cst->m_valueLow;
-						changeCount++;
+					uint32 result = outerSrc2cst->m_valueLow << innerSrc2cst->m_valueLow;
+					changeCount++;
 
-						std::swap(outerStatement, innerStatement);
-						std::swap(outerStatement.src1, innerStatement.src1);
-						std::swap(outerStatement.dst, innerStatement.dst);
-						innerStatement.src2 = MakeSymbolRef(MakeSymbol(SYM_CONSTANT, result));
-						changed = true;
+					std::swap(outerStatement, innerStatement);
+					std::swap(outerStatement.src1, innerStatement.src1);
+					std::swap(outerStatement.dst, innerStatement.dst);
+					innerStatement.src2 = MakeSymbolRef(MakeSymbol(SYM_CONSTANT, result));
+					changed = true;
 
-					}
 				}
 			}
 

--- a/src/Jitter_Optimize.cpp
+++ b/src/Jitter_Optimize.cpp
@@ -1143,10 +1143,11 @@ bool CJitter::ReorderAdd(StatementList& statements)
 		if(outerStatement.op != OP_ADD) continue;
 
 		CSymbolRef* outerDstSymbol = outerStatement.dst.get();
-		if(outerDstSymbol == NULL) continue;
+		assert(outerDstSymbol);
 
+		CSymbol* outerSrc2cst = dynamic_symbolref_cast(SYM_CONSTANT, outerStatement.src2);
 		//Don't mess with relatives
-		if(outerDstSymbol->GetSymbol()->IsRelative())
+		if(outerDstSymbol->GetSymbol()->IsRelative() || !outerSrc2cst)
 		{
 			continue;
 		}
@@ -1157,8 +1158,7 @@ bool CJitter::ReorderAdd(StatementList& statements)
 		if(innerStatement.op == OP_SLL && innerStatement.src1->Equals(outerDstSymbol))
 		{
 			CSymbol* innerSrc2cst = dynamic_symbolref_cast(SYM_CONSTANT, innerStatement.src2);
-			CSymbol* outerSrc2cst = dynamic_symbolref_cast(SYM_CONSTANT, outerStatement.src2);
-			if(innerSrc2cst && outerSrc2cst)
+			if(innerSrc2cst)
 			{
 				uint32 result = outerSrc2cst->m_valueLow << innerSrc2cst->m_valueLow;
 

--- a/src/Jitter_Optimize.cpp
+++ b/src/Jitter_Optimize.cpp
@@ -172,7 +172,7 @@ void CJitter::Compile()
 					dirty |= ConstantPropagation(versionedStatements.statements);
 					dirty |= ConstantFolding(versionedStatements.statements);
 					dirty |= CopyPropagation(versionedStatements.statements);
-					dirty |= CopyPropagation2(versionedStatements.statements);
+					dirty |= ReorderAdd(versionedStatements.statements);
 					dirty |= DeadcodeElimination(versionedStatements);
 
 					if(!dirty) break;
@@ -1130,7 +1130,7 @@ bool CJitter::ConstantPropagation(StatementList& statements)
 	return changed;
 }
 
-bool CJitter::CopyPropagation2(StatementList& statements)
+bool CJitter::ReorderAdd(StatementList& statements)
 {
 	bool changed = false;
 


### PR DESCRIPTION
in theory the same condition will work as is if `innerStatement.op == OP_SUB`

edit: for the 2nd commit, I used `CopyPropagation()` as base, since it didn't fit in the required model for optimisation, if you have a suggestion for a different name?

the 2nd commit finds
```cpp
REG[0] := REG[6] + 1
REG[0] := REG[0] << 4
```
applies left shift to the constant, then swaps the 2 statements around, to ensure we don't apply the shift multiple times

in doing so coupled with the 1st commit, we can find optimisations such as this
```cpp
REG[0] := REG[6] + 1
REG[0] := REG[0] << 4
REG[0] := REG[0] + 4
```
-->
```cpp
REG[0] := REG[6] << 4
REG[0] := REG[0] + 16
REG[0] := REG[0] + 4
```
-->
```cpp
REG[0] := REG[6] << 4
REG[0] := REG[0] + 20
```